### PR TITLE
doom deployment done

### DIFF
--- a/homework/3.kubernetes-intro/manifest/doom-deploy.yml
+++ b/homework/3.kubernetes-intro/manifest/doom-deploy.yml
@@ -1,0 +1,25 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: doom-deploy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: doom-app
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: doom-app
+    spec:
+      containers:
+      - image: storaxdev/kubedoom:0.5.0
+        name: kubedoom
+        ports:
+        - containerPort: 5900


### PR DESCRIPTION
Готов деплой с одной репликой.

Стратегия обновления RollingUpdate, причем:
* maxUnavailable=0 - нельзя уменьшать кол-во работающих подов
* maxSurge=1 - можно создать вдвое больше подов

Т.о. при обновлении деплоя сначала будет создан второй под, и только потом остановлен первый - даунтайма нет, как требовалось в постановке задачи:
> В деплойменте должна быть одна реплика, при этом при обновлении образа не должно возникать даунтайма
(то есть ситуации когда старый под был потушен, а новый еще на стартовал).
